### PR TITLE
Fix vuepress config

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -58,25 +58,25 @@ const blogSidebar = [
 
 module.exports = {
   title,
-  description: 'LDK is a flexible lightning implementation with supporting batteries (or modules).',
+  description: 'PDK is a Payjoin implementation with supporting modules.',
   theme: resolve(__dirname, '../../node_modules/@spiralbtc/vuepress-devkit-theme'),
   ...themeConfig({
     baseUrl,
     title,
     themeColor,
-    tags: ['Bitcoin', 'Lightning', 'LDK', 'Lightning Dev Kit', 'Documentation']
+    tags: ['Bitcoin', 'Payjoin', 'PDK', 'Payjoin Dev Kit', 'Documentation']
   }),
   themeConfig: {
     domain: baseUrl,
     logo: '/img/logo.svg',
     displayAllHeaders: false,
-    repo: 'lightningdevkit/lightningdevkit.org',
+    repo: 'payjoin/payjoindevkit.org',
     docsDir: 'docs',
     docsBranch: 'main',
     editLinks: true,
     sidebarDepth: 0,
     algolia: {
-      indexName: 'lightningdevkit',
+      indexName: 'payjoindevkit',
       appId: 'BH4D9OD16A',
       apiKey: '17ed8a4e16a1cb7d94da4e96f2ff817f',
       // See https://www.algolia.com/doc/api-reference/api-parameters/

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -175,7 +175,7 @@ module.exports = {
           ]
         }
       ],
-      copyright: 'Copyright © 2023 PDK Developers'
+      copyright: 'Copyright © 2024 PDK Developers'
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "lightningdevkit.org",
-  "version": "1.0.0",
+  "name": "payjoindevkit.org",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "lightningdevkit.org",
-      "version": "1.0.0",
+      "name": "payjoindevkit.org",
+      "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
         "@spiralbtc/vuepress-devkit-theme": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "payjoindevkit.org",
   "version": "0.0.1",
   "description": "Payjoin Dev Kit Documentation",
-  "author": "Lightning Dev Kit",
+  "author": "Payjoin Dev Kit",
   "license": "MIT",
   "bugs": "https://github.com/payjoin/payjoindevkit.org/issues",
   "homepage": "https://payjoindevkit.org",


### PR DESCRIPTION
Addresses https://github.com/payjoin/payjoindevkit.org/issues/7 and removes leftover references to LDK.