### PR TITLE
Fix typo: pidgeon -> pigeon

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ features:
 <div class="feature">
 <h3>PSBT Purity</h3>
 
-Standard Partially Signed Bitcoin Transaction support and an internet connection is all you need to Payjoin. No fancy transaction parsing or pidgeon-holed wallet architechture required.
+Standard Partially Signed Bitcoin Transaction support and an internet connection is all you need to Payjoin. No fancy transaction parsing or pigeon-holed wallet architechture required.
 
 </div>
 <div class="feature">


### PR DESCRIPTION
This PR fixes a tiny typo, changing "pidgeon" to "pigeon". I was today years old when I learned 

> "Pidgeon" is a surname from an archaic spelling of pigeon
https://en.wikipedia.org/wiki/Pidgeon