### PR TITLE
Remove line breaks in article markdown

### DIFF
--- a/docs/_blog/announcing-payjoin-foundation.md
+++ b/docs/_blog/announcing-payjoin-foundation.md
@@ -9,8 +9,6 @@ tags:
   - Foundation
 ---
 
-<br/>
-
 Commercial attempts to solve Bitcoin’s privacy have faced tremendous barriers. Short-term profit motives have delivered partial and temporary solutions, but transacting privately on Bitcoin remains a challenge.
 
 We formed Payjoin Foundation to pursue the long-term mission of addressing Bitcoin’s privacy problems. Our non-profit exists to develop open-source protocols that align economic incentives with network-wide privacy protection. We believe that users have a right to choose whether or not to reveal their on-chain activity, and that such protocols can even offer a more convenient and delightful experience than those that don't respect this choice.

--- a/docs/_blog/pdk-an-sdk-for-payjoin-transactions.md
+++ b/docs/_blog/pdk-an-sdk-for-payjoin-transactions.md
@@ -9,8 +9,6 @@ tags:
   - PDK
 ---
 
-<br/>
-
 PDK is here to make Payjoin a drop in upgrade for all software touching Bitcoin. I cover the project's history, why you should consider it to add Payjoin to your stack, and some of the project's priorities moving forward. The PDK team will be updating this new blog with development updates, feature forecasts and the details of releases.
   
 ## What is PDK?


### PR DESCRIPTION
This is causing a dashed line to go thru the first line of text.
Before:
<img width="1069" height="268" alt="image" src="https://github.com/user-attachments/assets/34104839-8b4c-4c1a-a6b8-8232fbc01dcb" />
After:
<img width="1069" height="268" alt="image" src="https://github.com/user-attachments/assets/8e17aa5d-39bf-4fd8-90c0-df6c0ff166d5" />


Also tested on mobile view


cc @DanGould 