### PR TITLE
fix: broken spacing caused by `<br />` in .md file

### DIFF
--- a/docs/_blog/payjoin-probing-attacks.md
+++ b/docs/_blog/payjoin-probing-attacks.md
@@ -8,7 +8,6 @@ tags:
   - privacy
   - integrations
 ---
-<h2></h2>
 
 The following is a conclusive address of concerns around UTXO probing attacks on
 Payjoin, clarification of why current mitigations are effective, and definitive

--- a/docs/_blog/yuval-kogman-foundation-advisor.md
+++ b/docs/_blog/yuval-kogman-foundation-advisor.md
@@ -10,8 +10,6 @@ tags:
   - Advisor
 ---
 
-<br/>
-
 Spiral Bitcoin Wizard and longtime Bitcoin privacy developer Yuval Kogman joins
 Payjoin Foundation as the first Advisory Board member. He draws on more than two
 decades of programming experience. Few others can boast Yuval's dedication to


### PR DESCRIPTION
We had a `<br />` in the `yuval-kogman-foundation...` article, which was causing spacing issues. It's not necessary since the article is a .md file so it's been removed. Also removed empty `<h2 />` in `payjoin-probing-attacks.md` for good measure.

Before:
<img width="1277" height="429" alt="Screenshot 2025-10-01 at 4 25 21 PM" src="https://github.com/user-attachments/assets/1fa75026-ad2b-44d7-bd5a-2661e257b8b0" />

After:
<img width="1318" height="477" alt="Screenshot 2025-10-01 at 4 25 36 PM" src="https://github.com/user-attachments/assets/e20f16e8-51ec-4827-9bb7-c97fc4f3af47" />
